### PR TITLE
Disable Werror for QEMU to increase succesful compilation probability

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ $ ../configure                                                    \
       --disable-vte                                               \
       --disable-opengl                                            \
       --disable-virglrenderer                                     \
+      --disable-werror                                            \
       --target-list=x86_64-linux-user                             \
       --enable-capstone=git                                       \
       --symcc-source=/path/to/symcc/sources                       \


### PR DESCRIPTION
This one is essential to build with newer clang