### PR TITLE
Better compatibility with some 32-bit target architectures

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -7664,10 +7664,12 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #ifdef TARGET_NR_stime /* not on alpha */
     case TARGET_NR_stime:
         {
-            time_t host_time;
-            if (get_user_sal(host_time, arg1))
+            struct timespec ts;
+            ts.tv_nsec = 0;
+            if (get_user_sal(ts.tv_sec, arg1)) {
                 return -TARGET_EFAULT;
-            return get_errno(stime(&host_time));
+            }
+            return get_errno(clock_settime(CLOCK_REALTIME, &ts));
         }
 #endif
 #ifdef TARGET_NR_alarm /* not on alpha */

--- a/target/mips/cpu.c
+++ b/target/mips/cpu.c
@@ -27,6 +27,14 @@
 #include "sysemu/kvm.h"
 #include "exec/exec-all.h"
 
+#define SymExpr void*
+#include "RuntimeCommon.h"
+
+static void init_env_exprs(MIPSCPU *cpu)
+{
+    memset(cpu->env_exprs, 0, sizeof(cpu->env_exprs));
+    _sym_register_expression_region(cpu->env_exprs, sizeof(cpu->env_exprs));
+}
 
 static void mips_cpu_set_pc(CPUState *cs, vaddr value)
 {
@@ -153,6 +161,8 @@ static void mips_cpu_realizefn(DeviceState *dev, Error **errp)
 static void mips_cpu_initfn(Object *obj)
 {
     MIPSCPU *cpu = MIPS_CPU(obj);
+    init_env_exprs(cpu);
+
     CPUMIPSState *env = &cpu->env;
     MIPSCPUClass *mcc = MIPS_CPU_GET_CLASS(obj);
 

--- a/target/mips/cpu.h
+++ b/target/mips/cpu.h
@@ -1067,6 +1067,9 @@ struct MIPSCPU {
 
     CPUNegativeOffsetState neg;
     CPUMIPSState env;
+
+    /* space for symbolic expressions corresponding to env */
+    void *env_exprs[512 + 1];   /* TCG_MAX_TEMPS + 1 (for NULL) */
 };
 
 


### PR DESCRIPTION
This small set of bugfixes improves compatibility with 32-bit architectures, especially MIPS.

- Fixed symbolic load not working for some 32-bit arch
- Backported a bugfix for a deprecated syscall usage
- Added env symbolic expressions in MIPS CPU

**Note about symbolic load :**
When `tcg_gen_qemu_ld_i32` is invoked during translation, the `addr` and `val (ret)` operands are getting simplified/folded into one TCG variable after the concrete operation. Thus, this prevents the later symbolic operation from retrieving the correct address value. It has probably something to do with the optimization feature of QEMU and the way a given target CPU (TCG frontend) invokes `tcg_gen_qemu_ld_i32` (use of TCG temporaries, constants). A tiny bugfix is proposed before finding the actual root cause.