### PR TITLE
Adding SymQEMU unit test suite to CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:22.04
+# prepare machine
+FROM ubuntu:22.04 as builder
 
 RUN apt update
 RUN apt install -y \
@@ -8,6 +9,9 @@ RUN apt install -y \
     git \
     python3 \
     python3-pip
+
+#
+FROM builder as symqemu
 
 COPY . /symqemu_source
 WORKDIR /symqemu_source
@@ -35,7 +39,6 @@ RUN ./configure                                                       \
 
 RUN make -j
 
-# Run QEMU base checks
 RUN make check
 
 WORKDIR /symqemu_source/tests/symqemu

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,8 @@ RUN ./configure                                                       \
 
 RUN make -j
 
+# Run QEMU base checks
+RUN make check
+
 WORKDIR /symqemu_source/tests/symqemu
 RUN python3 -m unittest test.py

--- a/README.md
+++ b/README.md
@@ -133,16 +133,16 @@ will facilitate correcting the issue.
 
 Current SymQEMU tests are run by the CI from the Docker container, the following
 test suites are currently in place:
-- [Unit tests][tests/unit/check-sym-runtime.c]: Those tests are made to validate
+- [Unit tests](tests/unit/check-sym-runtime.c): Those tests are made to validate
   specific instrumentation.
-- [Integration tests][tests/symqemu/]: Those tests are running SymQEMU on a set
+- [Integration tests](tests/symqemu/): Those tests are running SymQEMU on a set
   of binaries and compare the results to expected results. Note that those test
   cases can legitimately fail if some changes are made to SymQEMU (because for
   example, an improvement leads to generating new test cases). In that case,
   update the relevant files in `expected_outputs` folders. It would be nice to
   also validate those changes with a new test case.
 
-Also, refer to [QEMU's own tests suite documentation][https://www.qemu.org/docs/master/devel/testing.html].
+Also, refer to [QEMU's own tests suite documentation](https://www.qemu.org/docs/master/devel/testing.html).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ and binaries. The following invocation is known to work on Debian 10, Arch and
 Fedora 33:
 
 ``` shell
-
+$ mkdir build
+$ cd build
 $ ../configure                                                    \
       --audio-drv-list=                                           \
       --disable-sdl                                               \
@@ -42,15 +43,14 @@ $ ../configure                                                    \
       --disable-virglrenderer                                     \
       --disable-werror                                            \
       --target-list=x86_64-linux-user                             \
-      --symcc-source=</path/to/symcc>/sources                     \
-      --symcc-build=</path/to/symcc>/build
-
-$ make
+      --symcc-source=../symcc                                     \
+      --symcc-build=../symcc/build
+$ make -j
 ```
 
 This will build a relatively stripped-down emulator targeting 64-bit x86
 binaries. We also have experimental support for AARCH64. Working with 32-bit
-target architectures are possible in principle but will require a bit of work
+target architectures is possible in principle but will require a bit of work
 because the current implementation assumes that we can pass around host pointers
 in guest registers.
 

--- a/README.md
+++ b/README.md
@@ -102,13 +102,47 @@ cd ..
 
 Then build the SymQEMU image with (this will also run the tests):
 ```shell
-docker build -t symqemu  .
+docker build -t symqemu .
 ```
 
 You can use the docker with:
 ```shell
 docker run -it --rm symqemu
 ```
+
+## Contributing
+
+Use the GitHub project for reporting issues, and proposing changes.
+
+### Issues
+
+Please try to provide a minimal test case that demonstrates the problem, or ways
+to reproduce the behavior. If possible provide a precise line number if
+referring to some code. Ideally, make a PR with the test case demonstrating the
+failure (see next point).
+
+### Pull Requests
+
+Pull requests are very welcome. Pull requests will only be merged if all tests
+pass, and ideally with a new test case to validate the correctness of the
+proposed modifications. QEMU tests that are not specific to SymQEMU should pass
+(no regression).
+
+It is very valuable to also make a PR to add a test case for a known bug, this
+will facilitate correcting the issue.
+
+Current SymQEMU tests are run by the CI from the Docker container, the following
+test suites are currently in place:
+- [Unit tests][tests/unit/check-sym-runtime.c]: Those tests are made to validate
+  specific instrumentation.
+- [Integration tests][tests/symqemu/]: Those tests are running SymQEMU on a set
+  of binaries and compare the results to expected results. Note that those test
+  cases can legitimately fail if some changes are made to SymQEMU (because for
+  example, an improvement leads to generating new test cases). In that case,
+  update the relevant files in `expected_outputs` folders. It would be nice to
+  also validate those changes with a new test case.
+
+Also, refer to [QEMU's own tests suite documentation][https://www.qemu.org/docs/master/devel/testing.html].
 
 ## Documentation
 

--- a/tests/unit/check-sym-runtime.c
+++ b/tests/unit/check-sym-runtime.c
@@ -15,7 +15,9 @@
  */
 
 #include "qemu/osdep.h"
-#include "tcg.h"
+#include "tcg/tcg.h"
+#include "hw/i386/topology.h"
+#include "target/i386/cpu.h"
 #include "exec/helper-proto.h"
 
 #define SymExpr void*

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -231,5 +231,3 @@ foreach test_name, extra: tests
          suite: ['unit'])
     endif
 endforeach
-
-

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -220,5 +220,4 @@ foreach test_name, extra: tests
        timeout: slow_tests.get(test_name, 30),
        priority: slow_tests.get(test_name, 30),
        suite: ['unit'])
-
 endforeach

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -196,18 +196,15 @@ foreach test_name, extra: tests
        suite: ['unit'])
 endforeach
 
-# SymCC build
-deps = []
-deps += [qom]
-deps += [hwcore]
 
-test_ss = ss.source_set()
 test_name='check-sym-runtime'
 src = [test_name + '.c']
-test_ss= ss.source_set()
+
+# SymCC build
+deps = [qom, hwcore]
+test_ss = ss.source_set()
 src += test_ss.all_sources()
 deps += test_ss.all_dependencies()
-
 lwith = [libqemuutil, lib]
 
 exe = executable('check-sym-runtime.c',
@@ -218,16 +215,15 @@ exe = executable('check-sym-runtime.c',
 			  '-DCONFIG_TARGET="x86_64-linux-user-config-target.h"',
 			  '-DNEED_CPU_H',
 			  '-Ix86_64-linux-user'],
-                #include_directories : incdir,
-                #objects: [lib.extract_all_objects(recursive: true), symcc_libs],
-		link_args : ['../../../symcc/build/SymRuntime-prefix/src/SymRuntime-build/libSymRuntime.so',
-                            ],
 		dependencies: deps,
 		build_rpath: config_host['SYMCC_BUILD'],
-                #objects: [lib.extract_all_objects(recursive: true), symcc_libs],
+                objects: [symcc_libs],
 		link_with: lwith)
 
-test_env.append('LD_LIBRARY_PATH', '/home/aurel/work/Projects/SymQEMU/8.1/symqemu/symcc/build/SymRuntime-prefix/src/SymRuntime-build/')
+symcc_output=meson.current_build_dir() / 'symcc-tests-output'
+test_env.append('SYMCC_OUTPUT_DIR', symcc_output)
+r = run_command('mkdir',symcc_output )
+
 
 test(test_name, exe,
 	       depends: test_deps.get(test_name, []),

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -50,6 +50,7 @@ tests = {
   'test-qapi-util': [],
   'test-interval-tree': [],
   'test-xs-node': [qom],
+  'check-sym-runtime' : [qemuutil, qom, hwcore],
 }
 
 if have_system or have_tools
@@ -184,52 +185,51 @@ foreach test_name, extra: tests
     src += test_ss.all_sources()
     deps += test_ss.all_dependencies()
   endif
-  exe = executable(test_name, src, genh, dependencies: deps)
 
-  test(test_name, exe,
-       depends: test_deps.get(test_name, []),
-       env: test_env,
-       args: ['--tap', '-k'],
-       protocol: 'tap',
-       timeout: slow_tests.get(test_name, 30),
-       priority: slow_tests.get(test_name, 30),
-       suite: ['unit'])
+  # SymQEMU unit tests
+  if test_name == 'check-sym-runtime'
+    lwith = [lib]
+
+    exe = executable('check-sym-runtime.c',
+		     src,
+		     genh,
+		     c_args : ['-I../target/i386/',
+		  	       '-I../../symcc/runtime/',
+			       '-DCONFIG_TARGET="x86_64-linux-user-config-target.h"',
+			       '-DNEED_CPU_H',
+			       '-Ix86_64-linux-user'],
+		     dependencies: deps,
+		     build_rpath: config_host['SYMCC_BUILD'],
+                     objects: [symcc_libs],
+		     link_with: lwith
+                    )
+
+    symcc_output=meson.current_build_dir() / 'symcc-tests-output'
+    test_env.append('SYMCC_OUTPUT_DIR', symcc_output)
+    r = run_command('mkdir', symcc_output, check : false)
+
+    test(test_name, exe,
+	 depends: test_deps.get(test_name, []),
+	 env: test_env,
+	 args: ['--tap', '-k'],
+	 protocol: 'tap',
+	 timeout: slow_tests.get(test_name, 30),
+	 priority: slow_tests.get(test_name, 30),
+	 suite: ['unit'])
+
+  else
+
+    exe = executable(test_name, src, genh, dependencies: deps)
+
+    test(test_name, exe,
+         depends: test_deps.get(test_name, []),
+         env: test_env,
+         args: ['--tap', '-k'],
+         protocol: 'tap',
+         timeout: slow_tests.get(test_name, 30),
+         priority: slow_tests.get(test_name, 30),
+         suite: ['unit'])
+    endif
 endforeach
 
 
-test_name='check-sym-runtime'
-src = [test_name + '.c']
-
-# SymCC build
-deps = [qom, hwcore]
-test_ss = ss.source_set()
-src += test_ss.all_sources()
-deps += test_ss.all_dependencies()
-lwith = [libqemuutil, lib]
-
-exe = executable('check-sym-runtime.c',
-		src,
-		genh,
-		c_args : ['-I../target/i386/',
-		  	  '-I../../symcc/runtime/',
-			  '-DCONFIG_TARGET="x86_64-linux-user-config-target.h"',
-			  '-DNEED_CPU_H',
-			  '-Ix86_64-linux-user'],
-		dependencies: deps,
-		build_rpath: config_host['SYMCC_BUILD'],
-                objects: [symcc_libs],
-		link_with: lwith)
-
-symcc_output=meson.current_build_dir() / 'symcc-tests-output'
-test_env.append('SYMCC_OUTPUT_DIR', symcc_output)
-r = run_command('mkdir',symcc_output )
-
-
-test(test_name, exe,
-	       depends: test_deps.get(test_name, []),
-	       env: test_env,
-	       args: ['--tap', '-k'],
-	       protocol: 'tap',
-	       timeout: slow_tests.get(test_name, 30),
-	       priority: slow_tests.get(test_name, 30),
-	       suite: ['unit'])

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -195,3 +195,45 @@ foreach test_name, extra: tests
        priority: slow_tests.get(test_name, 30),
        suite: ['unit'])
 endforeach
+
+# SymCC build
+deps = []
+deps += [qom]
+deps += [hwcore]
+
+test_ss = ss.source_set()
+test_name='check-sym-runtime'
+src = [test_name + '.c']
+test_ss= ss.source_set()
+src += test_ss.all_sources()
+deps += test_ss.all_dependencies()
+
+lwith = [libqemuutil, lib]
+
+exe = executable('check-sym-runtime.c',
+		src,
+		genh,
+		c_args : ['-I../target/i386/',
+		  	  '-I../../symcc/runtime/',
+			  '-DCONFIG_TARGET="x86_64-linux-user-config-target.h"',
+			  '-DNEED_CPU_H',
+			  '-Ix86_64-linux-user'],
+                #include_directories : incdir,
+                #objects: [lib.extract_all_objects(recursive: true), symcc_libs],
+		link_args : ['../../../symcc/build/SymRuntime-prefix/src/SymRuntime-build/libSymRuntime.so',
+                            ],
+		dependencies: deps,
+		build_rpath: config_host['SYMCC_BUILD'],
+                #objects: [lib.extract_all_objects(recursive: true), symcc_libs],
+		link_with: lwith)
+
+test_env.append('LD_LIBRARY_PATH', '/home/aurel/work/Projects/SymQEMU/8.1/symqemu/symcc/build/SymRuntime-prefix/src/SymRuntime-build/')
+
+test(test_name, exe,
+	       depends: test_deps.get(test_name, []),
+	       env: test_env,
+	       args: ['--tap', '-k'],
+	       protocol: 'tap',
+	       timeout: slow_tests.get(test_name, 30),
+	       priority: slow_tests.get(test_name, 30),
+	       suite: ['unit'])

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -188,6 +188,13 @@ foreach test_name, extra: tests
 
   # SymQEMU unit tests
   if test_name == 'check-sym-runtime'
+
+    # lookup the libSymRuntime.so and add it as a dependence
+    libdir = meson.current_build_dir() / '../../' / config_host['SYMCC_BUILD']
+    symcc_runtime = cc.find_library('SymRuntime', dirs : libdir)
+    deps += [symcc_runtime]
+
+    # embeds most of qemu objects, including SymQEMU
     lwith = [lib]
 
     exe = executable('check-sym-runtime.c',
@@ -200,10 +207,10 @@ foreach test_name, extra: tests
 			       '-Ix86_64-linux-user'],
 		     dependencies: deps,
 		     build_rpath: config_host['SYMCC_BUILD'],
-                     objects: [symcc_libs],
 		     link_with: lwith
                     )
 
+    # Create the output file for symcc results
     symcc_output=meson.current_build_dir() / 'symcc-tests-output'
     test_env.append('SYMCC_OUTPUT_DIR', symcc_output)
     r = run_command('mkdir', symcc_output, check : false)

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -185,56 +185,40 @@ foreach test_name, extra: tests
     src += test_ss.all_sources()
     deps += test_ss.all_dependencies()
   endif
+  args =  []
+  lwith = []
 
-  # SymQEMU unit tests
+  # SymQEMU unit tests executable construction is a bit more complicated
   if test_name == 'check-sym-runtime'
-
     # lookup the libSymRuntime.so and add it as a dependence
     libdir = meson.current_build_dir() / '../../' / config_host['SYMCC_BUILD']
     symcc_runtime = cc.find_library('SymRuntime', dirs : libdir)
     deps += [symcc_runtime]
 
     # embeds most of qemu objects, including SymQEMU
-    lwith = [lib]
-
-    exe = executable('check-sym-runtime.c',
-		     src,
-		     genh,
-		     c_args : ['-I../target/i386/',
-		  	       '-I../../symcc/runtime/',
-			       '-DCONFIG_TARGET="x86_64-linux-user-config-target.h"',
-			       '-DNEED_CPU_H',
-			       '-Ix86_64-linux-user'],
-		     dependencies: deps,
-		     build_rpath: config_host['SYMCC_BUILD'],
-		     link_with: lwith
-                    )
+    lwith += [lib]
+    args +=  ['-I../target/i386/',
+	      '-I../../symcc/runtime/',
+	      '-DCONFIG_TARGET="x86_64-linux-user-config-target.h"',
+	      '-DNEED_CPU_H',
+	      '-Ix86_64-linux-user']
 
     # Create the output file for symcc results
     symcc_output=meson.current_build_dir() / 'symcc-tests-output'
     test_env.append('SYMCC_OUTPUT_DIR', symcc_output)
     r = run_command('mkdir', symcc_output, check : false)
+  endif
 
-    test(test_name, exe,
-	 depends: test_deps.get(test_name, []),
-	 env: test_env,
-	 args: ['--tap', '-k'],
-	 protocol: 'tap',
-	 timeout: slow_tests.get(test_name, 30),
-	 priority: slow_tests.get(test_name, 30),
-	 suite: ['unit'])
+  exe = executable(test_name, src, genh, dependencies: deps,
+                   c_args : args, link_with: lwith)
 
-  else
+  test(test_name, exe,
+       depends: test_deps.get(test_name, []),
+       env: test_env,
+       args: ['--tap', '-k'],
+       protocol: 'tap',
+       timeout: slow_tests.get(test_name, 30),
+       priority: slow_tests.get(test_name, 30),
+       suite: ['unit'])
 
-    exe = executable(test_name, src, genh, dependencies: deps)
-
-    test(test_name, exe,
-         depends: test_deps.get(test_name, []),
-         env: test_env,
-         args: ['--tap', '-k'],
-         protocol: 'tap',
-         timeout: slow_tests.get(test_name, 30),
-         priority: slow_tests.get(test_name, 30),
-         suite: ['unit'])
-    endif
 endforeach


### PR DESCRIPTION
It seems that check-sym-runtime.c was not ported over with the upgrade to QEMU 8
This PR adds it back:
- to the new meson buidl system 
- it will be called together with other qemu unit tests

