### PR TITLE
Fix compilation of arm-linux-user target.

### DIFF
--- a/accel/tcg/tcg-runtime-sym-common.c
+++ b/accel/tcg/tcg-runtime-sym-common.c
@@ -59,7 +59,8 @@ void *build_and_push_path_constraint(CPUArchState *env, void *arg1_expr, void *a
 /* Architecture-independent way to get the program counter */
 target_ulong get_pc(CPUArchState *env)
 {
-    target_ulong pc, cs_base;
+    vaddr pc;
+    uint64_t cs_base;
     uint32_t flags;
 
     cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);

--- a/accel/tcg/tcg-runtime-sym.c
+++ b/accel/tcg/tcg-runtime-sym.c
@@ -313,23 +313,23 @@ static void *sym_load_guest_internal(CPUArchState *env,
 }
 
 void *HELPER(sym_load_guest_i32)(CPUArchState *env,
-                                 target_ulong addr, void *addr_expr,
-                                 uint64_t length, target_ulong mmu_idx)
+                                 uint64_t addr, void *addr_expr,
+                                 uint64_t length, uint64_t mmu_idx)
 {
     return sym_load_guest_internal(env, addr, addr_expr, length, 4, mmu_idx);
 }
 
 void *HELPER(sym_load_guest_i64)(CPUArchState *env,
-                                 target_ulong addr, void *addr_expr,
-                                 uint64_t length, target_ulong mmu_idx)
+                                 uint64_t addr, void *addr_expr,
+                                 uint64_t length, uint64_t mmu_idx)
 {
     return sym_load_guest_internal(env, addr, addr_expr, length, 8, mmu_idx);
 }
 
 static void sym_store_guest_internal(CPUArchState *env,
                                      uint64_t value, void *value_expr,
-                                     target_ulong addr, void *addr_expr,
-                                     uint64_t length, target_ulong mmu_idx)
+                                     uint64_t addr, void *addr_expr,
+                                     uint64_t length, uint64_t mmu_idx)
 {
     /* Try an alternative address */
     if (addr_expr != NULL)
@@ -344,8 +344,8 @@ static void sym_store_guest_internal(CPUArchState *env,
 
 void HELPER(sym_store_guest_i32)(CPUArchState *env,
                                  uint32_t value, void *value_expr,
-                                 target_ulong addr, void *addr_expr,
-                                 uint64_t length, target_ulong mmu_idx)
+                                 uint64_t addr, void *addr_expr,
+                                 uint64_t length, uint64_t mmu_idx)
 {
     return sym_store_guest_internal(
         env, value, value_expr, addr, addr_expr, length, mmu_idx);
@@ -353,8 +353,8 @@ void HELPER(sym_store_guest_i32)(CPUArchState *env,
 
 void HELPER(sym_store_guest_i64)(CPUArchState *env,
                                  uint64_t value, void *value_expr,
-                                 target_ulong addr, void *addr_expr,
-                                 uint64_t length, target_ulong mmu_idx)
+                                 uint64_t addr, void *addr_expr,
+                                 uint64_t length, uint64_t mmu_idx)
 {
     return sym_store_guest_internal(
         env, value, value_expr, addr, addr_expr, length, mmu_idx);


### PR DESCRIPTION
Fix for #53.

There seems to be a linking issue with the unit tests @aurelf, can you have a look?

```bash
FAILED: tests/unit/check-sym-runtime
cc -m64 -mcx16  -o tests/unit/check-sym-runtime tests/unit/check-sym-runtime.p/check-sym-runtime.c.o -Wl,--as-needed -Wl,--no-undefined -pie -Wl,--whole-archive libevent-loop-base.fa libqom.fa libhwcore.fa -Wl,--no-whole-archive -fsanitize=undefined -fsanitize=address -fstack-protector-strong -Wl,-z,relro -Wl,-z,now -Wl,--warn-common -Wl,-rpath,/home/rmalmain/Projects/symcc/symcc/build/SymRuntime-prefix/src/SymRuntime-build -Wl,-rpath-link,/home/rmalmain/Projects/symcc/symcc/build/SymRuntime-prefix/src/SymRuntime-build libqemu-arm-linux-user.fa -Wl,--start-group libqemuutil.a libevent-loop-base.fa libqom.fa libhwcore.fa /home/rmalmain/Projects/symcc/symcc/build/SymRuntime-prefix/src/SymRuntime-build/libSymRuntime.so /usr/lib/libz.so /usr/lib/libcapstone.so /usr/lib/libdw.so /usr/lib/libelf.so -Xlinker --dynamic-list=/home/rmalmain/Projects/symqemu/symqemu-official/plugins/qemu-plugins.symbols -lrt -lm -pthread /usr/lib/libglib-2.0.so /usr/lib/libgmodule-2.0.so -Wl,--end-group
/usr/bin/ld: libqemu-arm-linux-user.fa.p/linux-user_main.c.o:/home/rmalmain/Projects/symqemu/symqemu-official/build/../linux-user/main.c:82: multiple definition of `guest_base'; tests/unit/check-sym-runtime.p/check-sym-runtime.c.o:/home/rmalmain/Projects/symqemu/symqemu-official/build/../tests/unit/check-sym-runtime.c:29: first defined here
/usr/bin/ld: libqemu-arm-linux-user.fa.p/linux-user_main.c.o: in function `main':
/home/rmalmain/Projects/symqemu/symqemu-official/build/../linux-user/main.c:674: multiple definition of `main'; tests/unit/check-sym-runtime.p/check-sym-runtime.c.o:/home/rmalmain/Projects/symqemu/symqemu-official/build/../tests/unit/check-sym-runtime.c:367: first defined here
/usr/bin/ld: libqemu-arm-linux-user.fa.p/linux-user_main.c.o:(.bss+0x1424): multiple definition of `__odr_asan.guest_base'; tests/unit/check-sym-runtime.p/check-sym-runtime.c.o:(.bss+0x40): first defined here
/usr/bin/ld: libcommon.fa.p/gdbstub_syscalls.c.o: warning: relocation against `gdbserver_state' in read-only section `.text.unlikely'
/usr/bin/ld: libqemu-arm-linux-user.fa.p/accel_tcg_tb-maint.c.o: in function `do_tb_flush':
/home/rmalmain/Projects/symqemu/symqemu-official/build/../accel/tcg/tb-maint.c:776:(.text+0x228): undefined reference to `tcg_region_reset_all'
/usr/bin/ld: libqemu-arm-linux-user.fa.p/accel_tcg_translate-all.c.o: in function `setjmp_gen_code':
/home/rmalmain/Projects/symqemu/symqemu-official/build/../accel/tcg/translate-all.c:271:(.text+0x989): undefined reference to `tcg_ctx'
/usr/bin/ld: /home/rmalmain/Projects/symqemu/symqemu-official/build/../accel/tcg/translate-all.c:276:(.text+0x9e9): undefined reference to `tcg_ctx'
/usr/bin/ld: /home/rmalmain/Projects/symqemu/symqemu-official/build/../accel/tcg/translate-all.c:276:(.text+0x9f2): undefined reference to `tcg_func_start'
/usr/bin/ld: /home/rmalmain/Projects/symqemu/symqemu-official/build/../accel/tcg/translate-all.c:281:(.text+0xae1): undefined reference to `tcg_ctx'
/usr/bin/ld: /home/rmalmain/Projects/symqemu/symqemu-official/build/../accel/tcg/translate-all.c:284:(.text+0xbc7): undefined reference to `tcg_ctx'
/usr/bin/ld: /home/rmalmain/Projects/symqemu/symqemu-official/build/../accel/tcg/translate-all.c:284:(.text+0xbd0): undefined reference to `tcg_gen_code'
```