### PR TITLE
Add a docker-compose file for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,7 @@ RUN apt update && apt install -y \
     z3 \
     libz3-dev \
     libz3-dev \
-    libzstd-dev \
-    colordiff \
-    xxd \
-    wdiff
+    libzstd-dev
 
 RUN pip install --user meson
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # prepare machine
-FROM ubuntu:22.04 as builder
+FROM ubuntu:22.04 as base
 
 RUN apt update && apt install -y \
     ninja-build \
@@ -16,7 +16,10 @@ RUN apt update && apt install -y \
     z3 \
     libz3-dev \
     libz3-dev \
-    libzstd-dev
+    libzstd-dev \
+    colordiff \
+    xxd \
+    wdiff
 
 RUN pip install --user meson
 
@@ -35,20 +38,33 @@ RUN if  [ $LLVM_VERSION -eq 12 ] || [ $LLVM_VERSION -eq 13 ] || [ $LLVM_VERSION 
     else mkdir /llvm && cd  /llvm &&  wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh ${LLVM_VERSION};   	\
     fi
 
+RUN <<EOF cat > /configure_symqemu.sh
+../configure                                                    \
+      --audio-drv-list=                                         \
+      --disable-sdl                                             \
+      --disable-gtk                                             \
+      --disable-vte                                             \
+      --disable-opengl                                          \
+      --disable-virglrenderer                                   \
+      --target-list=x86_64-linux-user,riscv64-linux-user        \
+      --enable-debug                                            \
+      --enable-debug-tcg                                        \
+      --symcc-rt-llvm-version="$LLVM_VERSION"                   \
+      --disable-werror
+EOF
+
+RUN chmod u+x /configure_symqemu.sh
+
+FROM base as symqemu-dev
+
+WORKDIR /symqemu_source
+
+FROM base as symqemu
+
 COPY . /symqemu_source
 WORKDIR /symqemu_source
 
-RUN mkdir build && cd build && ../configure                           \
-          --audio-drv-list=                                           \
-          --disable-sdl                                               \
-          --disable-gtk                                               \
-          --disable-vte                                               \
-          --disable-opengl                                            \
-          --disable-virglrenderer                                     \
-          --target-list=x86_64-linux-user,riscv64-linux-user          \
-          --enable-debug                                              \
-          --enable-debug-tcg                                          \
-          --symcc-rt-llvm-version="$LLVM_VERSION"
+RUN mkdir build && cd build && /configure_symqemu.sh
 
 RUN cd build && make -j
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,13 @@ docker run -it --rm symqemu
 
 ## Build with Docker Compose
 
-Sometimes, it is more convenient to use docker-compose while developing SymQEMU, especially to avoid rebuilding for
-each change. It can both build `symqemu` and `symqemu-dev`.
+Sometimes, it is more convenient to use docker-compose while developing SymQEMU,
+especially to avoid rebuilding for each change. It can both build `symqemu` and
+`symqemu-dev`.
 
-Beware however, the container and the host directory will be synchronized: each change in the container's source folder
-will be reflected on the host and vice versa (except for the build subfolder).
+Beware however, the container and the host directory will be synchronized: each
+change in the container's source folder will be reflected on the host and vice
+versa (except for the build subfolder).
 
 A script is available to quickly get docker-compose: `./dev.sh`.
 
@@ -122,7 +124,19 @@ docker-compose up -d symqemu-dev
 It is finally possible to attach to the container:
 ```bash
 docker-compose exec -it symqemu-dev /bin/bash
-````
+```
+
+Building and testing in one line (confugure only needed the first time, it is
+automatically rerun when needed):
+
+```bash
+docker-compose exec -it  symqemu-dev /bin/bash -c "cd build && /configure_symqemu.sh && make -j && make check"
+```
+
+Running symqemu integration tests:
+```bash
+docker-compose exec -it  symqemu-dev /bin/bash -c "cd /symqemu_source/tests/symqemu && python3 -m unittest test.py"
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,31 @@ You can use the docker with:
 docker run -it --rm symqemu
 ```
 
+## Build with Docker Compose
+
+Sometimes, it is more convenient to use docker-compose while developing SymQEMU, especially to avoid rebuilding for
+each change. It can both build `symqemu` and `symqemu-dev`.
+
+Beware however, the container and the host directory will be synchronized: each change in the container's source folder
+will be reflected on the host and vice versa (except for the build subfolder).
+
+A script is available to quickly get docker-compose: `./dev.sh`.
+
+For example, to build the `symqemu-dev` service:
+```bash
+docker-compose build symqemu-dev
+```
+
+Then, it is necessary to up the service:
+```bash
+docker-compose up -d symqemu-dev
+```
+
+It is finally possible to attach to the container:
+```bash
+docker-compose exec -it symqemu-dev /bin/bash
+````
+
 ## Contributing
 
 Use the GitHub project for reporting issues, and proposing changes.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First of all, make sure the
 [symcc-rt](https://github.com/eurecom-s3/symcc-rt.git) submodule is initialized:
 
 ``` shell
-$ git submodule update --init --recursive subprojects/symcc-rt
+git submodule update --init --recursive subprojects/symcc-rt
 ```
 
 Make sure that QEMU's build dependencies are installed. Most package managers
@@ -23,18 +23,18 @@ or `dnf builddep qemu` on Fedora and CentOS.
 The following invocation is known to work on Ubuntu 22.04 and Arch:
 
 ``` shell
-$ mkdir build
-$ cd build
-$ ../configure                                                    \
-      --audio-drv-list=                                           \
-      --disable-sdl                                               \
-      --disable-gtk                                               \
-      --disable-vte                                               \
-      --disable-opengl                                            \
-      --disable-virglrenderer                                     \
-      --disable-werror                                            \
-      --target-list=x86_64-linux-user
-$ make -j
+mkdir build
+cd build
+../configure                                                    \
+    --audio-drv-list=                                           \
+    --disable-sdl                                               \
+    --disable-gtk                                               \
+    --disable-vte                                               \
+    --disable-opengl                                            \
+    --disable-virglrenderer                                     \
+    --disable-werror                                            \
+    --target-list=x86_64-linux-user
+make -j
 ```
 
 This will build a relatively stripped-down emulator targeting 64-bit x86

--- a/README.md
+++ b/README.md
@@ -105,35 +105,36 @@ Sometimes, it is more convenient to use docker-compose while developing SymQEMU,
 especially to avoid rebuilding for each change. It can both build `symqemu` and
 `symqemu-dev`.
 
-Beware however, the container and the host directory will be synchronized: each
-change in the container's source folder will be reflected on the host and vice
-versa (except for the build subfolder).
+Beware however, test the container and the host directory will be synchronized:
+each change in the container's source folder will be reflected on the host and
+vice versa (except for the build sub-folder).
 
-A script is available to quickly get docker-compose: `./dev.sh`.
+A script is available to quickly get docker-compose: `./dev.sh`. Alternatively
+the following commands can be used:
 
-For example, to build the `symqemu-dev` service:
+- Build the `symqemu-dev` service:
 ```bash
 docker-compose build symqemu-dev
 ```
 
-Then, it is necessary to up the service:
+- Start the service:
 ```bash
 docker-compose up -d symqemu-dev
 ```
 
-It is finally possible to attach to the container:
+- Attach to the container:
 ```bash
 docker-compose exec -it symqemu-dev /bin/bash
 ```
 
-Building and testing in one line (confugure only needed the first time, it is
+- Building and testing in one line (configure only needed the first time, it is
 automatically rerun when needed):
 
 ```bash
 docker-compose exec -it  symqemu-dev /bin/bash -c "cd build && /configure_symqemu.sh && make -j && make check"
 ```
 
-Running symqemu integration tests:
+- Running SymQEMU integration tests:
 ```bash
 docker-compose exec -it  symqemu-dev /bin/bash -c "cd /symqemu_source/tests/symqemu && python3 -m unittest test.py"
 ```

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+docker-compose build symqemu-dev
+docker-compose up -d symqemu-dev
+docker-compose exec -it symqemu-dev /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  symqemu-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: symqemu-dev
+    volumes:
+      - ./:/symqemu_source
+      - /symqemu_source/build
+    command: tail -f /dev/null
+
+  symqemu:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: symqemu
+    command: tail -f /dev/null


### PR DESCRIPTION
It's mainly to avoid recompiling everything when we modify a single file in the source code.