### PR TITLE
Fix to issue #70 - Path to the compiled binary is wrong in the main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Several compilation options are available:
 ## Running SymQEMU
 
 If you built SymQEMU as described above, the binary will be in
-`x86_64-linux-user/symqemu-x86_64`. For a quick test, try the following:
+`build/qemu-x86_64`. For a quick test, try the following:
 
 ``` shell
 $ mkdir /tmp/output

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you built SymQEMU as described above, the binary will be in
 
 ``` shell
 $ mkdir /tmp/output
-$ echo test | x86_64-linux-user/qemu-x86_64 /bin/cat -t -
+$ echo test | build/qemu-x86_64 /bin/cat -t -
 This is SymCC running with the QSYM backend
 [STAT] SMT: { "solving_time": 0, "total_time": 51010 }
 [STAT] SMT: { "solving_time": 523 }
@@ -84,7 +84,7 @@ same
 [settings](https://github.com/eurecom-s3/symcc/blob/master/docs/Configuration.txt),
 and you can even run SymQEMU with `symcc_fuzzing_helper` for [hybrid
 fuzzing](https://github.com/eurecom-s3/symcc/blob/master/docs/Fuzzing.txt): just
-prefix the target command with `x86_64-linux-user/symqemu-x86_64`. (Note that
+prefix the target command with `build/qemu-x86_64`. (Note that
 you'll have to run AFL in QEMU mode by adding `-Q` to its command line; the
 fuzzing helper will automatically pick up the setting and use QEMU mode too.)
 

--- a/accel/tcg/tcg-runtime-sym.c
+++ b/accel/tcg/tcg-runtime-sym.c
@@ -603,21 +603,23 @@ static void *sym_movcond_internal(CPUArchState *env,
     if (c1_expr == NULL && c2_expr == NULL && v1_expr == NULL && v2_expr == NULL) {
         return NULL;
     }
+    int c1_bits = (c1_expr != NULL) ? _sym_bits_helper(c1_expr) : result_bits;
+    int c2_bits = (c2_expr != NULL) ? _sym_bits_helper(c2_expr) : result_bits;
 
     if (c1_expr == NULL) {
-        c1_expr = _sym_build_integer(c1, _sym_bits_helper(c2_expr));
+        c1_expr = _sym_build_integer(c1, c2_bits);
     }
 
     if (c2_expr == NULL) {
-        c2_expr = _sym_build_integer(c2, _sym_bits_helper(c1_expr));
+        c2_expr = _sym_build_integer(c2, c1_bits);
     }
 
     if (v1_expr == NULL) {
-        v1_expr = _sym_build_integer(v1, _sym_bits_helper(c1_expr));
+        v1_expr = _sym_build_integer(v1, c1_bits);
     }
 
     if (v2_expr == NULL) {
-        v2_expr = _sym_build_integer(v2, _sym_bits_helper(c1_expr));
+        v2_expr = _sym_build_integer(v2, c1_bits);
     }
 
     assert(_sym_bits_helper(c1_expr) == result_bits);


### PR DESCRIPTION
The name of the symqemu binary and its path changed from what it was originally described in the README.md
It seems the old path used to be under x86_64-linux-user/symqemu-x86_64, now the path and the name changed to build/qemu-x86_64