### PR TITLE
Fix scanf issue56

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Several compilation options are available:
 ## Running SymQEMU
 
 If you built SymQEMU as described above, the binary will be in
-`x86_64-linux-user/symqemu-x86_64`. For a quick test, try the following:
+`build/qemu-x86_64`. For a quick test, try the following:
 
 ``` shell
 $ mkdir /tmp/output

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you built SymQEMU as described above, the binary will be in
 
 ``` shell
 $ mkdir /tmp/output
-$ echo test | x86_64-linux-user/qemu-x86_64 /bin/cat -t -
+$ echo test | build/qemu-x86_64 /bin/cat -t -
 This is SymCC running with the QSYM backend
 [STAT] SMT: { "solving_time": 0, "total_time": 51010 }
 [STAT] SMT: { "solving_time": 523 }
@@ -84,7 +84,7 @@ same
 [settings](https://github.com/eurecom-s3/symcc/blob/master/docs/Configuration.txt),
 and you can even run SymQEMU with `symcc_fuzzing_helper` for [hybrid
 fuzzing](https://github.com/eurecom-s3/symcc/blob/master/docs/Fuzzing.txt): just
-prefix the target command with `x86_64-linux-user/symqemu-x86_64`. (Note that
+prefix the target command with `build/qemu-x86_64`. (Note that
 you'll have to run AFL in QEMU mode by adding `-Q` to its command line; the
 fuzzing helper will automatically pick up the setting and use QEMU mode too.)
 

--- a/accel/tcg/tcg-runtime-sym.c
+++ b/accel/tcg/tcg-runtime-sym.c
@@ -603,21 +603,23 @@ static void *sym_movcond_internal(CPUArchState *env,
     if (c1_expr == NULL && c2_expr == NULL && v1_expr == NULL && v2_expr == NULL) {
         return NULL;
     }
+    int c1_bits = (c1_expr != NULL) ? _sym_bits_helper(c1_expr) : result_bits;
+    int c2_bits = (c2_expr != NULL) ? _sym_bits_helper(c2_expr) : result_bits;
 
     if (c1_expr == NULL) {
-        c1_expr = _sym_build_integer(c1, _sym_bits_helper(c2_expr));
+        c1_expr = _sym_build_integer(c1, c2_bits);
     }
 
     if (c2_expr == NULL) {
-        c2_expr = _sym_build_integer(c2, _sym_bits_helper(c1_expr));
+        c2_expr = _sym_build_integer(c2, c1_bits);
     }
 
     if (v1_expr == NULL) {
-        v1_expr = _sym_build_integer(v1, _sym_bits_helper(c1_expr));
+        v1_expr = _sym_build_integer(v1, c1_bits);
     }
 
     if (v2_expr == NULL) {
-        v2_expr = _sym_build_integer(v2, _sym_bits_helper(c1_expr));
+        v2_expr = _sym_build_integer(v2, c1_bits);
     }
 
     assert(_sym_bits_helper(c1_expr) == result_bits);


### PR DESCRIPTION
After some debugging, it was noticeable that the interruption is triggered because it tries to access to address null in Memory. So in order to prevent this violation, a check is added before. If c1_expr & c2_expr are not null, then the _sym_bits_helper can be applied, otherwise, take the result_bits value.
This solution does not make code to support scanf, it only prevents to access to null memory address.

The problem was replicated:
./qemu-x86_64 /tmp/test.out                                                                                                         
This is SymCC running with the QSYM backend                                                                                                                                                                 
100                                                                                                                                                                                                         
[STAT] SMT: { "solving_time": 0, "total_time": 2988732 }                                                                                                                                                    
[STAT] SMT: { "solving_time": 651 }

...

[INFO] New testcase: /tmp/mes_outputs/000021-optimistic
[STAT] SMT: { "solving_time": 92478, "total_time": 3130248 }
[STAT] SMT: { "solving_time": 104662 }
[STAT] SMT: { "solving_time": 104662, "total_time": 3143178 }
[STAT] SMT: { "solving_time": 109186 }
qemu-x86_64: QEMU internal SIGSEGV {code=MAPERR, addr=0x14}
Erreur de segmentation (core dumped)

After the fix NO MORE SIGSEGV:

./qemu-x86_64 /tmp/test.out                                                                                                         
This is SymCC running with the QSYM backend                                                                                                                                                                 
100                                                                                                                                                                                                         
[STAT] SMT: { "solving_time": 0, "total_time": 1716356 }                                                                                                                                                    
[STAT] SMT: { "solving_time": 672 }  

...

[INFO] New testcase: /home/executer/Documents/summer2026/symqemu/tests/1phase_issues/scanf/real_issue/fix_prevent_null_access/outccc/000021-optimistic
[STAT] SMT: { "solving_time": 95143, "total_time": 1857289 }
[STAT] SMT: { "solving_time": 108113 }
[STAT] SMT: { "solving_time": 108113, "total_time": 1870679 }
[STAT] SMT: { "solving_time": 112770 }
[STAT] SMT: { "solving_time": 112770, "total_time": 1878918 }
[STAT] SMT: { "solving_time": 141505 }
[STAT] SMT: { "solving_time": 141505, "total_time": 1908141 }
[STAT] SMT: { "solving_time": 174061 }
[STAT] SMT: { "solving_time": 174061, "total_time": 1942651 }
[STAT] SMT: { "solving_time": 202434 }
[INFO] New testcase: /home/executer/Documents/summer2026/symqemu/tests/1phase_issues/scanf/real_issue/fix_prevent_null_access/outccc/000022
ccc