### PR TITLE
Fix scanf issue14

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Several compilation options are available:
 ## Running SymQEMU
 
 If you built SymQEMU as described above, the binary will be in
-`x86_64-linux-user/symqemu-x86_64`. For a quick test, try the following:
+`build/qemu-x86_64`. For a quick test, try the following:
 
 ``` shell
 $ mkdir /tmp/output

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you built SymQEMU as described above, the binary will be in
 
 ``` shell
 $ mkdir /tmp/output
-$ echo test | x86_64-linux-user/qemu-x86_64 /bin/cat -t -
+$ echo test | build/qemu-x86_64 /bin/cat -t -
 This is SymCC running with the QSYM backend
 [STAT] SMT: { "solving_time": 0, "total_time": 51010 }
 [STAT] SMT: { "solving_time": 523 }
@@ -84,7 +84,7 @@ same
 [settings](https://github.com/eurecom-s3/symcc/blob/master/docs/Configuration.txt),
 and you can even run SymQEMU with `symcc_fuzzing_helper` for [hybrid
 fuzzing](https://github.com/eurecom-s3/symcc/blob/master/docs/Fuzzing.txt): just
-prefix the target command with `x86_64-linux-user/symqemu-x86_64`. (Note that
+prefix the target command with `build/qemu-x86_64`. (Note that
 you'll have to run AFL in QEMU mode by adding `-Q` to its command line; the
 fuzzing helper will automatically pick up the setting and use QEMU mode too.)
 

--- a/accel/tcg/tcg-runtime-sym.c
+++ b/accel/tcg/tcg-runtime-sym.c
@@ -603,21 +603,23 @@ static void *sym_movcond_internal(CPUArchState *env,
     if (c1_expr == NULL && c2_expr == NULL && v1_expr == NULL && v2_expr == NULL) {
         return NULL;
     }
+    int c1_bits = (c1_expr != NULL) ? _sym_bits_helper(c1_expr) : result_bits;
+    int c2_bits = (c2_expr != NULL) ? _sym_bits_helper(c2_expr) : result_bits;
 
     if (c1_expr == NULL) {
-        c1_expr = _sym_build_integer(c1, _sym_bits_helper(c2_expr));
+        c1_expr = _sym_build_integer(c1, c2_bits);
     }
 
     if (c2_expr == NULL) {
-        c2_expr = _sym_build_integer(c2, _sym_bits_helper(c1_expr));
+        c2_expr = _sym_build_integer(c2, c1_bits);
     }
 
     if (v1_expr == NULL) {
-        v1_expr = _sym_build_integer(v1, _sym_bits_helper(c1_expr));
+        v1_expr = _sym_build_integer(v1, c1_bits);
     }
 
     if (v2_expr == NULL) {
-        v2_expr = _sym_build_integer(v2, _sym_bits_helper(c1_expr));
+        v2_expr = _sym_build_integer(v2, c1_bits);
     }
 
     assert(_sym_bits_helper(c1_expr) == result_bits);

--- a/target/i386/tcg/emit.c.inc
+++ b/target/i386/tcg/emit.c.inc
@@ -344,7 +344,20 @@ static void gen_writeback(DisasContext *s, X86DecodedInsn *decode, int opn, TCGv
         if (op->has_ea) {
             gen_op_st_v(s, op->ot, v, s->A0);
         } else {
-            gen_op_mov_reg_v(s, op->ot, op->n, v);
+	    if(decode->b == 0xbe || decode->b == 0xbf){
+		    if(op->ot == MO_32){
+		    	tcg_gen_ext32s_tl(cpu_regs[op->n], v);
+		    }
+		    else if(op->ot == MO_16){
+		    	tcg_gen_ext16s_tl(cpu_regs[op->n], v);
+		    }
+		    else{
+		        tcg_gen_mov_tl(cpu_regs[op->n], v);
+		    }
+	    }
+	    else{
+		    gen_op_mov_reg_v(s, op->ot, op->n, v);
+	    }
         }
         break;
     case X86_OP_MMX:


### PR DESCRIPTION
Once debugging and analyzing the stack of the program just before generate the symbol for movzx (tcg_gen_ext32u_i64), it was evident that SymQEMU, at least in this part of the code, it only checked the size of the instruction, but not if it was a zero or sign extension. A possible and feasible fix is to utilize the element of b in decode parameter as it contains the exact instruction to translate (there is a table in target/i386/tcg/decode-new.c.inc). It shows a MOVSX when 0xbe or 0xbf, and to respect the size, a check of it is done in the same nested if condition statements. Then it directly translates the instruction.

The solid test that shows the behavior of this problem is...
#include <stdio.h>
#include <stdlib.h>
#include <stdint.h>
#include <fcntl.h>
#include <unistd.h>

int main(int argc, char *argv[]) {
    int fd;
    uint8_t user_input[1] = {0};

    if (argc < 2) {
        fprintf(stderr, "Usage: %s <fichier_input>\n", argv[0]);
        return 1;
    }

    fd = open(argv[1], O_RDONLY);
    if (fd == -1) {
        perror("Erreur d'ouverture du fichier");
        return 1;
    }

    if (read(fd, user_input, 1) < 1) {
        fprintf(stderr, "Erreur : Le fichier doit faire au moins 1 octet.\n");
        close(fd);
        return 1;
    }
    close(fd);

    // =============================================================
    // CONDITION MOVSX (Sign Extension)
    // =============================================================
    // Interprétation en signé (int8_t) -> Génère l'instruction MOVSX
    int32_t dest_signed = (int8_t)user_input[0];

    // Le solveur SMT de SymQEMU va chercher à satisfaire la condition négative
    if (dest_signed == -54) {
        printf("[MOVSX] Succès : L'entrée a été étendue avec son signe négatif (%d)\n", dest_signed);
    } else {
        printf("[MOVSX] Autre valeur (%d)\n", dest_signed);
    }

    return 0;
}


The given input was 0x4A which should touch the else branch, and SMT has to find for -54 which is 0xCA...
///////////////////////////////////////////////////////////////////////
Running before the patch these were the results:
///////////////////////////////////////////////////////////////////////
Generate a translated file result and then look for 0fbec0 which is movsx eax, al:

executer@executer-INVALID:~/Documents/summer2026/symqemu/tests/1phase_issues/undetected_sign/movsx/real_problem/specific_neg$ grep -B 2 -A 20 "0fbec0" trans_movsx 
IN: 
0x7e308dd64686:  
OBJD-T: 410fbe5101498d79010fbec04d8d5001400fbef64989f98d4ad080f909771a

OP:
 call sym_load_host_i32,$0x5,$1,loc9_expr,env,$0xfffffffffffffff8,$0x4
 ld_i32 loc9,env,$0xfffffffffffffff8
 setcond_i32 loc13,loc9,$0x0,lt
 call sym_setcond_i32,$0x1,$1,loc13_expr,env,loc9,loc9_expr,$0x0,$0x0,$0x2,loc13
 brcond_i32 loc9,$0x0,lt,$L0
 call sym_notify_block,$0x1,$0,$0x7e307c0dfb40
 call sym_store_host,$0x1,$0,$0x0,env,$0xfffffffffffffffc,$0x1
 st8_i32 $0x0,env,$0xfffffffffffffffc

 ---- 00007e308dd64686 0000000000000000
 call sym_add_i64,$0x5,$1,loc2_expr,r9,r9_expr,$0x1,$0x0
 add_i64 loc2,r9,$0x1
 mov_i64 tmp17_expr,loc2_expr
 mov_i64 tmp17,loc2
 qemu_ld_a64_i64 loc0,loc2,noat+al+sb,2
 call sym_load_guest_i64,$0x1,$1,loc0_expr,env,tmp17,tmp17_expr,$0x1,$0x2
 call sym_zext,$0x5,$1,rdx_expr,loc0_expr,$0x4    <-------------------SymQEMU considered as a zext (zero extension)
 ext32u_i64 rdx,loc0     <------------------- And then the unsigned extension
 


By checking the output of SymQEMU, there were only 0s and this 0x2 that did not touch the -54 branch

executer@executer-INVALID:~/Documents/summer2026/symqemu/tests/1phase_issues/undetected_sign/movsx/real_problem/specific_neg$ hexdump 000000
0000000 0002


///////////////////////////////////////////////////////////////////////
Running with the patch these were the results:
///////////////////////////////////////////////////////////////////////

Generate a translated file result and then look for 0fbec0 which is movsx eax, al:
executer@executer-INVALID:~/Documents/summer2026/symqemu/tests/1phase_issues/undetected_sign/movsx/specific_neg$ grep -B 2 -A 20 "0fbec0" trans_movsx                                                       
IN:                                                                                                                                                                                                         
0x794742f59686:                                                                                                                                                                                             
OBJD-T: 410fbe5101498d79010fbec04d8d5001400fbef64989f98d4ad080f909771a                                                                                                                                      
                                                                                                                                                                                                            
OP:                                                                                                                                                                                                         
 call sym_load_host_i32,$0x5,$1,loc9_expr,env,$0xfffffffffffffff8,$0x4                                                                                                                                      
 ld_i32 loc9,env,$0xfffffffffffffff8                                                                                                                                                                        
 setcond_i32 loc13,loc9,$0x0,lt                                                                                                                                                                             
 call sym_setcond_i32,$0x1,$1,loc13_expr,env,loc9,loc9_expr,$0x0,$0x0,$0x2,loc13                                                                                                                            
 brcond_i32 loc9,$0x0,lt,$L0                                                                                                                                                                                
 call sym_notify_block,$0x1,$0,$0x7947340de800                                                                                                                                                              
 call sym_store_host,$0x1,$0,$0x0,env,$0xfffffffffffffffc,$0x1                                                                                                                                              
 st8_i32 $0x0,env,$0xfffffffffffffffc                                                                                                                                                                       
                                                                                                                                                                                                            
 ---- 0000794742f59686 0000000000000000                                                                                                                                                                     
 call sym_add_i64,$0x5,$1,loc2_expr,r9,r9_expr,$0x1,$0x0                                                                                                                                                    
 add_i64 loc2,r9,$0x1                                                                                                                                                                                       
 mov_i64 tmp17_expr,loc2_expr                                                                                                                                                                               
 mov_i64 tmp17,loc2                                                                                                                                                                                         
 qemu_ld_a64_i64 loc0,loc2,noat+al+sb,2                                                                                                                                                                     
 call sym_load_guest_i64,$0x1,$1,loc0_expr,env,tmp17,tmp17_expr,$0x1,$0x2                                                                                                                                   
 call sym_sext,$0x5,$1,rdx_expr,loc0_expr,$0x4                    <--------------Now sext (SIGN EXTENSION) was set!                                                                                                                                          
 ext32s_i64 rdx,loc0 <-------------------------- Correct signed extension






By checking the output of SymQEMU, only 0s and one was able to suggest the -54 branch (as it is supposed to work!)

/Documents/summer2026/symqemu/tests/1phase_issues/undetected_sign/movsx/specific_neg/casted0$ hexdump 000000
0000000 00ca <----------Remember 0xca = -54, so CORRECT



